### PR TITLE
feat(build): Add Windows standalone build script and update workflows

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -67,19 +67,63 @@ jobs:
             dist/kraina_cli
           retention-days: 30
 
+  build-windows:
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Create virtual environment
+        run: |
+          python -m venv .venv
+
+      - name: Install dependencies
+        run: |
+          .venv\Scripts\activate
+          python -m pip install --upgrade pip
+          pip install pyinstaller-hooks-contrib==2025.5
+          pip install -e .
+          pip install pyinstaller
+
+      - name: Build standalone executables
+        run: |
+          .venv\Scripts\activate
+          .\build_standalone.bat
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kraina-windows-x64
+          path: |
+            dist/kraina_app.exe
+            dist/kraina_cli.exe
+          retention-days: 30
+
   release:
-    needs: build-linux
+    needs: [build-linux, build-windows]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     permissions:
       contents: write
 
     steps:
-      - name: Download artifacts
+      - name: Download Linux artifacts
         uses: actions/download-artifact@v4
         with:
           name: kraina-linux-x64
-          path: artifacts
+          path: artifacts/linux
+
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: kraina-windows-x64
+          path: artifacts/windows
 
       - name: Display structure of downloaded files
         run: |
@@ -90,7 +134,9 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            artifacts/kraina_app
-            artifacts/kraina_cli
+            artifacts/linux/kraina_app
+            artifacts/linux/kraina_cli
+            artifacts/windows/kraina_app.exe
+            artifacts/windows/kraina_cli.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # KrAIna - AI-Powered Tools for Everyday Use
 
-![os](https://badgen.net/badge/Windows/planned/yellow)
+![os](https://badgen.net/badge/Windows/supported/green)
 ![os](https://badgen.net/badge/Linux/supported/green)
 ![os](https://badgen.net/badge/Python/3.10|3.11|3.12/blue)
 
@@ -379,7 +379,7 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 ### Development Installation
 
 **Requirements:**
-- Python >= 3.10 + IDLE (Tk GUI)
+- Python >= 3.10 + IDLE (Tk GUI) < 3.13
 - Python venv package  
 - Git
 
@@ -387,9 +387,16 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 ```bash
 # Clone and setup
 git clone <repository>
-cd krAIna
+cd krAIna/
+
+## Linux
 python3 -m venv .venv
 source .venv/bin/activate
+pip install -e .
+
+## Windows
+python -m venv .venv
+.venv\Scripts\activate
 pip install -e .
 
 # Run from source
@@ -402,11 +409,15 @@ python app/kraina_cli.py --help
 ```bash
 # Linux
 ./build_standalone.sh
+# Windows
+./build_standalone.bat
 ```
 
 **Build Output:**
-- `dist/kraina_app` - GUI executable (~110MB)
-- `dist/kraina_cli` - CLI executable (~11MB)
+- `dist/kraina_app` - GUI executable (~110MB) for Linux
+- `dist/kraina_app.exe` - GUI executable (~90MB) for Windows
+- `dist/kraina_cli` - CLI executable (~11MB) for Linux
+- `dist/kraina_cli.exe` - CLI executable (~9MB) for Windows
 - Self-contained with all dependencies
 - No Python installation required on target systems
 

--- a/app/kraina_cli.py
+++ b/app/kraina_cli.py
@@ -35,7 +35,8 @@ def run_app_and_cmd(args=None):
         # proc_exe = subprocess.Popen(<Your executable path>, shell=True)
         # proc_exe.send_signal(subprocess.signal.SIGTERM)
         if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
-            kraina_app_path = Path(sys.argv[0]).parent.resolve() / "kraina_app"
+            kraina_app_name = "kraina_app.exe" if sys.platform == "win32" else "kraina_app"
+            kraina_app_path = Path(sys.argv[0]).parent.resolve() / kraina_app_name
             if not kraina_app_path.exists():
                 raise FileNotFoundError(f"Kraina app not found at {kraina_app_path}")
             subprocess.Popen([str(kraina_app_path)], start_new_session=True)
@@ -43,7 +44,7 @@ def run_app_and_cmd(args=None):
             subprocess.Popen([sys.executable, Path(__file__).parent / "kraina_app.py"], start_new_session=True)
         # Try to connect to just started application to use IPC
         start = time.time()
-        while time.time() <= start + 15.0:
+        while time.time() <= start + 45.0:
             try:
                 run_cmd(args)
             except ConnectionRefusedError:

--- a/build_standalone.bat
+++ b/build_standalone.bat
@@ -1,0 +1,128 @@
+@echo off
+rem KrAIna Chat Standalone Build Script for Windows
+rem This script builds a standalone executable from the kraina_app application
+
+setlocal enabledelayedexpansion
+
+echo ==========================================
+echo Building KrAIna Chat Standalone Application
+echo ==========================================
+
+rem Ensure we're in the correct directory
+if not exist "app\kraina_app.py" (
+    echo Error: app\kraina_app.py not found. Please run this script from the project root.
+    exit /b 1
+)
+
+rem Check if virtual environment exists
+if not exist ".venv" (
+    echo Error: Virtual environment not found. Please create one first.
+    exit /b 1
+)
+
+rem Activate virtual environment
+echo Activating virtual environment...
+call .venv\Scripts\activate.bat
+if %errorlevel% neq 0 (
+    echo Error: Failed to activate virtual environment.
+    exit /b 1
+)
+
+rem Check if PyInstaller is installed
+pyinstaller --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo PyInstaller not found. Installing...
+    pip install pyinstaller
+)
+
+rem Clean previous builds
+echo Cleaning previous builds...
+if exist "build" rmdir /s /q "build"
+if exist "*.spec" del /q "*.spec"
+
+rem Build the GUI application
+echo Building standalone kraina_app...
+pyinstaller ^
+    --onefile ^
+    --windowed ^
+    app\kraina_app.py ^
+    --paths src ^
+    --add-data src\kraina_chat\img:kraina_chat\img ^
+    --add-data src\kraina\libs\notification\logo.png:kraina\libs\notification\ ^
+    --add-data src\kraina\assistants:kraina\assistants ^
+    --add-data src\kraina\snippets:kraina\snippets ^
+    --add-data src\kraina\tools:kraina\tools ^
+    --add-data src\kraina\macros:kraina\macros ^
+    --add-data src\kraina\templates:kraina\templates ^
+    --collect-all tkinterweb ^
+    --collect-all tkinterweb_tkhtml ^
+    --collect-all sv_ttk ^
+    --collect-all pywinstyles ^
+    --hidden-import=tiktoken_ext.openai_public ^
+    --hidden-import=tiktoken_ext ^
+    --hidden-import=PIL._tkinter_finder ^
+    --hidden-import=aenum ^
+    --hidden-import=pywinstyles ^
+    --hidden-import=ctypes.wintypes ^
+    --exclude-module pkg_resources ^
+    --exclude-module gi ^
+    --exclude-module gi.repository.Rsvg ^
+    --exclude-module gi.repository.GdkPixbuf ^
+    --exclude-module gi.repository.cairo ^
+    --exclude-module gi.repository.Gio ^
+    --exclude-module gi.repository.GLib ^
+    --exclude-module gi.repository.GObject ^
+    --exclude-module pygobject ^
+    --exclude-module pgi ^
+    --exclude-module python-xlib ^
+    --icon=img\logo.ico ^
+    --splash=img\kraina_banner_loading.png
+
+if %errorlevel% neq 0 (
+    echo Error: Failed to build kraina_app.
+    exit /b 1
+)
+
+rem Build the CLI application
+echo Building standalone kraina_cli...
+pyinstaller ^
+    --onefile ^
+    app\kraina_cli.py ^
+    --paths src ^
+    --add-data src\kraina\templates:kraina\templates ^
+    --add-data src\kraina\libs\notification\logo.png:kraina\libs\notification\ ^
+    --hidden-import=windows_toasts ^
+    --exclude-module pkg_resources ^
+    --exclude-module gi.repository.Rsvg ^
+    --exclude-module gi.repository.GdkPixbuf ^
+    --exclude-module gi.repository.cairo ^
+    --exclude-module gi.repository.Gio ^
+    --exclude-module gi.repository.GLib ^
+    --exclude-module gi.repository.GObject ^
+    --exclude-module pygobject ^
+    --exclude-module pgi ^
+    --exclude-module python-xlib ^
+    --icon=img\logo.ico
+
+if %errorlevel% neq 0 (
+    echo Error: Failed to build kraina_cli.
+    exit /b 1
+)
+
+rem Check if build was successful
+if exist "dist\kraina_app.exe" if exist "dist\kraina_cli.exe" (
+    echo ==========================================
+    echo Build completed successfully!
+    echo Executable location: dist\kraina_app.exe
+    for %%A in ("dist\kraina_app.exe") do echo File size: %%~zA bytes
+    echo Executable location: dist\kraina_cli.exe
+    for %%A in ("dist\kraina_cli.exe") do echo File size: %%~zA bytes
+    echo ==========================================
+) else (
+    echo Build failed! Check the output above for errors.
+    exit /b 1
+)
+
+echo.
+echo Build process completed. You can now run the applications from the dist folder.
+pause 

--- a/copyQ/README.md
+++ b/copyQ/README.md
@@ -59,8 +59,10 @@ To import these actions into CopyQ:
 3. Edit snippet:
    * Adjust the path to your needs:
     ``` js
-   // Set KrAIna installation folder in your home folder 
-   var kraina_dir = '/Documents/krAIna/';
+   // Set KrAIna CLI app path releated to user home directory
+   // for linux use slash /, for windows use double backslash \\
+   // e.g. '/tools/krAIna/' for linux, '\\tools\\krAIna\\' for windows
+   var kraina_app = '/tools/krAIna/';
    ```
    * Change or remove shortcuts if needed (global shortcut ALT+SHIFT+1, CopyQ shortcut ALT+RETURN).
 4. Save and that's all.

--- a/copyQ/ai_pycharm_commit.ini
+++ b/copyQ/ai_pycharm_commit.ini
@@ -14,8 +14,10 @@ Command="
             }
         }
 
-        // Set KrAIna CLI app path
-        var kraina_app = '/tools/krAIna/kraina_cli' + batOrSh();
+        // Set KrAIna CLI app path releated to user home directory
+        // for linux use slash /, for windows use double backslash \\
+        // e.g. '/tools/krAIna/' for linux, '\\tools\\krAIna\\' for windows
+        var kraina_app = '/tools/krAIna/';
         var repos_dir = 'repos/'
 
         // Get Project name from Pycharm title window
@@ -42,7 +44,7 @@ Command="
         ff.write(diff_result);
         ff.close();
 
-        const result = execute(Dir().homePath() + kraina_app, 'RUN_SNIPPET_WITH_FILE', 'commit', ff.fileName());
+        const result = execute(Dir().homePath() + kraina_app + 'kraina_cli' + batOrSh(), 'RUN_SNIPPET_WITH_FILE', 'commit', ff.fileName());
         if (result.exit_code != 0) {
             popup('Error', str(result.stderr).trim(), 3000);
             abort();

--- a/copyQ/ai_screenshot_select_ocr.ini
+++ b/copyQ/ai_screenshot_select_ocr.ini
@@ -13,8 +13,10 @@ Command="
             return '';
         }
     }
-    // Set KrAIna CLI app path
-    var kraina_app = '/tools/krAIna/kraina_cli' + batOrSh();
+    // Set KrAIna CLI app path releated to user home directory
+    // for linux use slash /, for windows use double backslash \\
+    // e.g. '/tools/krAIna/' for linux, '\\tools\\krAIna\\' for windows
+    var kraina_app = '/tools/krAIna/';
     var image = input();
     if (image.size() == 0) {
          popup('Abort', 'No image area specified', 1000);
@@ -24,7 +26,7 @@ Command="
     f.open();
     f.write(image);
     f.close();
-    const result = execute(Dir().homePath() + kraina_app, 'RUN_SNIPPET', 'ocr', f.fileName());
+    const result = execute(Dir().homePath() + kraina_app + 'kraina_cli' + batOrSh(), 'RUN_SNIPPET', 'ocr', f.fileName());
     if (result.exit_code != 0) {
         popup('Error', str(result.stderr).trim(), 3000);
         abort();

--- a/copyQ/ai_select.ini
+++ b/copyQ/ai_select.ini
@@ -14,8 +14,10 @@ Command="
         }
     }
 
-    // Set KrAIna CLI app path
-    var kraina_app = '/tools/krAIna/kraina_cli' + batOrSh();
+    // Set KrAIna CLI app path releated to user home directory
+    // for linux use slash /, for windows use double backslash \\
+    // e.g. '/tools/krAIna/' for linux, '\\tools\\krAIna\\' for windows
+    var kraina_app = '/tools/krAIna/';
     copy();
     var to_process = str(clipboard());
     if (!to_process) {
@@ -35,7 +37,7 @@ Command="
         abort();
       }
     }
-    const snippets = execute(Dir().homePath() + kraina_app, 'GET_LIST_OF_SNIPPETS');
+    const snippets = execute(Dir().homePath() + kraina_app + 'kraina_cli' + batOrSh(), 'GET_LIST_OF_SNIPPETS');
     var items = str(snippets.stdout).trim().split(',');
 
     var selected_index = dialog('.title', 'Select Snippets', '.list:Select', items);
@@ -47,7 +49,7 @@ Command="
     ff.write(to_process);
     ff.close();
 
-    const result = execute(Dir().homePath() + kraina_app, 'RUN_SNIPPET_WITH_FILE', items[Number(selected_index)], ff.fileName());
+    const result = execute(Dir().homePath() + kraina_app + 'kraina_cli' + batOrSh(), 'RUN_SNIPPET_WITH_FILE', items[Number(selected_index)], ff.fileName());
     if (result.exit_code != 0) {
         popup('Error', str(result.stderr).trim(), 3000);
         abort();

--- a/copyQ/ai_translate.ini
+++ b/copyQ/ai_translate.ini
@@ -13,11 +13,13 @@ Command="
             return '';
         }
     }
-    // Set KrAIna CLI app path
-    var kraina_app = '/tools/krAIna/kraina_cli' + batOrSh();
+    // Set KrAIna CLI app path releated to user home directory
+    // for linux use slash /, for windows use double backslash \\
+    // e.g. '/tools/krAIna/' for linux, '\\tools\\krAIna\\' for windows
+    var kraina_app = '/tools/krAIna/';
     copy();
     // Example how to run snippets via Chat app using IPC
-    const result = execute(Dir().homePath() + kraina_app, 'RUN_SNIPPET', 'translate', clipboard());
+    const result = execute(Dir().homePath() + kraina_app + 'kraina_cli' + batOrSh(), 'RUN_SNIPPET', 'translate', clipboard());
     if (result.exit_code != 0) {
         copy(str(result.stderr).trim());
     } else {

--- a/copyQ/kraina_run.ini
+++ b/copyQ/kraina_run.ini
@@ -13,9 +13,11 @@ Command="
             return '';
         }
     }
-    // Set KrAIna CLI app path
-    var kraina_app = '/tools/krAIna/kraina_cli' + batOrSh();
-    const result = execute(Dir().homePath() + kraina_app, 'SHOW_APP');
+    // Set KrAIna CLI app path releated to user home directory
+    // for linux use slash /, for windows use double backslash \\
+    // e.g. '/tools/krAIna/' for linux, '\\tools\\krAIna\\' for windows
+    var kraina_app = '/tools/krAIna/';
+    const result = execute(Dir().homePath() + kraina_app + 'kraina_cli' + batOrSh(), 'SHOW_APP');
     if (result.exit_code != 0) {
         copy(str(result.stderr).trim());
     } else {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kraina"
 version = "0.1.0"
 description = "Kraina is a set of AI-powered tools for everyday use."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 dependencies = [
     "aenum>=3.1.16,<4.0.0",
     "anthropic>=0.57.1,<1.0.0",

--- a/src/kraina/libs/klembord/winclipboard.py
+++ b/src/kraina/libs/klembord/winclipboard.py
@@ -8,7 +8,7 @@ UNSUPPORTED = {
     "CF_BITMAP": 2,
     "CF_DIB": 8,
     "CF_DIBV5": 17,
-    "CF_DIF": 5,ST
+    "CF_DIF": 5,
     "CF_DSPBITMAP": 0x0082,
     "CF_DSPENHMETAFILE": 0x008E,
     "CF_DSPMETAFILEPICT": 0x0083,


### PR DESCRIPTION
#4 

- Introduced `build_standalone.bat` for building standalone executables on Windows, including error handling for environment setup and build processes.
- Updated GitHub Actions workflow to include a new job for building Windows executables, ensuring compatibility with Python 3.12 and managing dependencies.
- Adjusted `pyproject.toml` to restrict Python version compatibility to `<3.13`.
- Enhanced CLI application to dynamically determine the executable name based on the platform.
- Increased timeout for connecting to the application after launch to improve reliability.
- - Update documentation